### PR TITLE
Dell R230s BMO Objects

### DIFF
--- a/clusters/okd-prod/bmo-hosts.yaml
+++ b/clusters/okd-prod/bmo-hosts.yaml
@@ -1,0 +1,96 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dell1-secret
+type: Opaque
+data:
+  username: cm9vdA==
+  password: Y2Fsdmlu
+---
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: dell1-r230
+  namespace: openshift-machine-api
+  annotations:
+    argocd.argoproj.io/sync-wave: "4"
+spec:
+  online: true
+  bootMACAddress: 50:9A:4C:92:EF:6D
+  bmc:
+    address: idrac-virtualmedia://192.168.100.1
+    credentialsName: dell1-secret
+    disableCertificateVerification: true
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dell2-secret
+type: Opaque
+data:
+  username: cm9vdA==
+  password: Y2Fsdmlu
+---
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: dell2-r230
+  namespace: openshift-machine-api
+  annotations:
+    argocd.argoproj.io/sync-wave: "4"
+spec:
+  online: true
+  bootMACAddress: 50:9A:4C:98:43:38
+  bmc:
+    address: idrac-virtualmedia://192.168.100.2
+    credentialsName: dell2-secret
+    disableCertificateVerification: true
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dell3-secret
+type: Opaque
+data:
+  username: cm9vdA==
+  password: Y2Fsdmlu
+---
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: dell3-r230
+  namespace: openshift-machine-api
+  annotations:
+    argocd.argoproj.io/sync-wave: "4"
+spec:
+  online: true
+  bootMACAddress: 6C:2B:59:7A:5F:92
+  bmc:
+    address: idrac-virtualmedia://192.168.100.3
+    credentialsName: dell3-secret
+    disableCertificateVerification: true
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dell5-secret
+type: Opaque
+data:
+  username: cm9vdA==
+  password: Y2Fsdmlu
+---
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: dell5-r230
+  namespace: openshift-machine-api
+  annotations:
+    argocd.argoproj.io/sync-wave: "4"
+spec:
+  online: true
+  bootMACAddress: 50:9A:4C:97:24:0A
+  bmc:
+    address: idrac-virtualmedia://192.168.100.5
+    credentialsName: dell4-secret
+    disableCertificateVerification: true

--- a/clusters/okd-prod/kustomization.yaml
+++ b/clusters/okd-prod/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - acm-operator.yaml
   - acm-hub.yaml
   - baremetal-operator.yaml
+  - bmo-hosts.yaml
   - local-storage-operator.yaml
   - LocalVolumeDiscovery.yaml
   - LocalVolume.yaml


### PR DESCRIPTION
This pull request adds configuration for managing several Dell bare metal hosts in the production OKD cluster. It introduces new `Secret` and `BareMetalHost` resources for each server and updates the kustomization to include these new resources.

**Bare Metal Host Management:**

* Added `Secret` resources for BMC credentials for four Dell servers (`dell1-secret`, `dell2-secret`, `dell3-secret`, `dell5-secret`) in `bmo-hosts.yaml`.
* Added `BareMetalHost` resources for four Dell R230 servers, each referencing its corresponding secret and specifying BMC connection details.

**Cluster Configuration:**

* Updated `kustomization.yaml` to include the new `bmo-hosts.yaml` file, ensuring these resources are managed by ArgoCD.

**Note:** There appears to be a mismatch in the credentials for `dell5-r230`, which references `dell4-secret` instead of `dell5-secret`—this should be reviewed for correctness.